### PR TITLE
add viewScriptOperation and tableScriptOperation extension settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To start searching execute `Search Everywhere` command or press `Crtl + T`.
 
 First time opening search bar could take a time, results are cahed then, to clear the cache execute `Search Everywhere With Cache Clear`  or press `Crtl + Shift + T`. 
 
-For a Tables and Views extension will run `Select top (1000)`, `Alter` for stored procedures and functions. 
+For a Tables and Views extension will run `Select top (1000)`, `Alter` for stored procedures and functions. This behavior can be changed by modifying the `viewScriptOperation` and `tableScriptOperation` extension settings.
 
  *<a href="https://www.flaticon.com/free-icons/ui" title="ui icons">Extension icon created by apien - Flaticon</a>*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ads-searcheverywhere",
-	"version": "0.0.1",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ads-searcheverywhere",
-			"version": "0.0.1",
+			"version": "1.1.1",
 			"dependencies": {
 				"memory-cache": "^0.2.0"
 			},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ads-searcheverywhere",
 	"displayName": "Search Everywhere",
 	"description": "Search tables, views, stored procedures, functions by name or code.",
-    "icon": "png/search.png",
+	"icon": "png/search.png",
 	"publisher": "MikhailT",
 	"version": "1.1.1",
 	"engines": {
@@ -29,30 +29,48 @@
 			}
 		],
 		"configuration": {
-		"type": "object",
-        "title": "Search Everywhere configuration",
-        "properties": {
-        	"searchEverywhere.columnsInTable": {
-				"type": "boolean",
-                "default": false,
-                "description": "Add columns information to Tables(could have performance impact)"
-            	}
+			"type": "object",
+			"title": "Search Everywhere",
+			"properties": {
+				"searchEverywhere.columnsInTable": {
+					"type": "boolean",
+					"default": false,
+					"description": "Add columns information to Tables (could have performance impact)"
+				},
+				"searchEverywhere.viewScriptOperation": {
+					"type": "string",
+					"default": "Select",
+					"enum": [
+						"Select",
+						"Alter"
+					],
+					"description": "The type of script that will be opened upon selecting a view"
+				},
+				"searchEverywhere.tableScriptOperation": {
+					"type": "string",
+					"default": "Select",
+					"enum": [
+						"Select",
+						"Create"
+					],
+					"description": "The type of script that will be opened upon selecting a table"
+				}
 			}
-		 },
-		 "keybindings": [
-            {
-                "key": "ctrl+t",
-                "command": "ads-searcheverywhere.search"
-            },
+		},
+		"keybindings": [
 			{
-                "key": "ctrl+shift+t",
-                "command": "ads-searcheverywhere.searchAndCacheClear"
-            }
+				"key": "ctrl+t",
+				"command": "ads-searcheverywhere.search"
+			},
+			{
+				"key": "ctrl+shift+t",
+				"command": "ads-searcheverywhere.searchAndCacheClear"
+			}
 		]
-	},	
+	},
 	"repository": {
-    "type": "git",
-    "url": "https://github.com/MikhailProfile/SearchEverywhere.git"
+		"type": "git",
+		"url": "https://github.com/MikhailProfile/SearchEverywhere.git"
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
@@ -79,5 +97,11 @@
 	},
 	"dependencies": {
 		"memory-cache": "^0.2.0"
+	},
+	"__metadata": {
+		"id": "101",
+		"publisherDisplayName": "MikhailT",
+		"publisherId": "MikhailT",
+		"isPreReleaseVersion": false
 	}
 }


### PR DESCRIPTION
#5 
This commit adds two extension settings to allow users to open a CREATE script for tables and an ALTER script for views. I love this extension and for my use cases it would be helpful to be able to generate table CREATE scripts which also have information about a table's indexes, primary keys, and default values!
![image](https://github.com/MikhailProfile/SearchEverywhere/assets/55362012/8c00f940-3f95-4f68-8c7a-5297691049fe)
